### PR TITLE
Kubernetes volumes

### DIFF
--- a/kubernetes-networks/configmap.yml
+++ b/kubernetes-networks/configmap.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-conf
+  namespace: homework
+data:
+  webserver.conf: |
+    server {
+    listen       8000;
+    location / {
+        root   /homework;
+        index  index.html;
+    }
+    }

--- a/kubernetes-networks/deployment.yml
+++ b/kubernetes-networks/deployment.yml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: webserver
+  namespace: homework
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      nodeSelector:
+        homework: "true"
+      volumes:
+      - name: workdir
+        emptyDir: {}
+      - name: nginx-conf
+        configMap:
+          name: nginx-conf
+      initContainers:
+        - name: init-container
+          image: busybox
+          command: ['/bin/sh', '-c', 'echo "<html><body><h1>hello world </h1></body></html>" > /init/index.html']
+          volumeMounts:
+          - name: workdir
+            mountPath: "/init"
+      containers:
+      - name: web-server
+        image: nginx
+        ports:
+        - containerPort: 8000
+        volumeMounts:
+        - name: workdir
+          mountPath: /homework
+        - name: "nginx-conf"
+          mountPath: /etc/nginx/conf.d/webserver.conf
+          subPath: webserver.conf
+        lifecycle:
+          preStop:
+            exec:
+              command: ['/bin/sh', '-c', 'rm -f /homework/index.html']
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000          
+          initialDelaySeconds: 5
+          periodSeconds: 5
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1

--- a/kubernetes-networks/ingress.yml
+++ b/kubernetes-networks/ingress.yml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: webserver-ingress
+  namespace: homework
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /index.html
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: homework.otus
+      http:
+        paths:
+          - path: /homepage
+            pathType: Prefix
+            backend:
+              service:
+                name: webserver-service
+                port:
+                  number: 8000
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: webserver-service
+                port:
+                  number: 8000

--- a/kubernetes-networks/namespace.yml
+++ b/kubernetes-networks/namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework

--- a/kubernetes-networks/service.yml
+++ b/kubernetes-networks/service.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: webserver-service
+  namespace: homework
+spec:
+  selector:
+    app: nginx
+  type: ClusterIP
+  ports:
+  - port: 8000
+    protocol: TCP

--- a/kubernetes-volumes/cm.yml
+++ b/kubernetes-volumes/cm.yml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm-webserver
+  namespace: homework
+data:
+  file: |
+    val1=1
+    val2=2

--- a/kubernetes-volumes/configmap.yml
+++ b/kubernetes-volumes/configmap.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-conf
+  namespace: homework
+data:
+  webserver.conf: |
+    server {
+    listen       8000;
+    location / {
+        root   /homework;
+        index  index.html;
+    }
+    }

--- a/kubernetes-volumes/deployment.yml
+++ b/kubernetes-volumes/deployment.yml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: webserver
+  namespace: homework
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      nodeSelector:
+        homework: "true"
+      volumes:
+      - name: workdir
+        persistentVolumeClaim:
+          claimName: pvc-webserver
+      - name: cm-webserver
+        configMap:
+          name: cm-webserver
+      - name: nginx-conf
+        configMap:
+          name: nginx-conf
+      initContainers:
+        - name: init-container
+          image: busybox
+          command: ['/bin/sh', '-c', 'echo "<html><body><h1>hello world </h1></body></html>" > /init/index.html']
+          volumeMounts:
+          - name: workdir
+            mountPath: "/init"
+      containers:
+      - name: web-server
+        image: nginx
+        ports:
+        - containerPort: 8000
+        volumeMounts:
+        - name: workdir
+          mountPath: /homework
+        - name: "nginx-conf"
+          mountPath: /etc/nginx/conf.d/webserver.conf
+          subPath: webserver.conf
+        - name: cm-webserver
+          mountPath: /homework/conf/file
+          subPath: file
+        lifecycle:
+          preStop:
+            exec:
+              command: ['/bin/sh', '-c', 'rm -f /homework/index.html']
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000          
+          initialDelaySeconds: 5
+          periodSeconds: 5
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1

--- a/kubernetes-volumes/ingress.yml
+++ b/kubernetes-volumes/ingress.yml
@@ -1,0 +1,34 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: webserver-ingress
+  namespace: homework
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: homework.otus
+      http:
+        paths:
+          - path: /homepage
+            pathType: Prefix
+            backend:
+              service:
+                name: webserver-service
+                port:
+                  number: 8000
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: webserver-service
+                port:
+                  number: 8000
+          - path: /(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: webserver-service
+                port:
+                  number: 8000

--- a/kubernetes-volumes/namespace.yml
+++ b/kubernetes-volumes/namespace.yml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework

--- a/kubernetes-volumes/pvc.yml
+++ b/kubernetes-volumes/pvc.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: pvc-webserver
+  namespace: homework
+spec:
+  storageClassName: "sc-homework"
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10M

--- a/kubernetes-volumes/service.yml
+++ b/kubernetes-volumes/service.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: webserver-service
+  namespace: homework
+spec:
+  selector:
+    app: nginx
+  type: ClusterIP
+  ports:
+  - port: 8000
+    protocol: TCP

--- a/kubernetes-volumes/storageClass.yml
+++ b/kubernetes-volumes/storageClass.yml
@@ -1,0 +1,8 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: sc-homework
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "false"
+provisioner: k8s.io/minikube-hostpath
+reclaimPolicy: Retain 


### PR DESCRIPTION
# Выполнено ДЗ №

 - [x ] Основное ДЗ
 - [ x] Задание со *

## В процессе сделано:
 - создан манифест PersistentVolumeClaim запрашивающий хранилище с storageClass по-умолчанию
 - создан configMap содержащий произвольные значения
 - в существующем deployment заменен тип хранилища на созданный  pvc 
 - в deployment добавлена новая точка монтирования на созданный configMap и внесены изменения в манифест ingress, так, чтобы его содержимое можно было получить, обратившись по url /conf/file
 - Создан манифест storageClass.yml описывающий объект типа storageClass с provisioner https://k8s.io/minikube-hostpath и reclaimPolicy Retain
 - внесены изменения в pvc.yml так, чтобы в нем запрашивалось созданного выше storageClassа

## Как запустить проект:
  - выполнить  команду kubectl apply -f  namespace.yml 
 - выполнить  команду kubectl apply -f configmap.yml 
 - выполнить  команду kubectl apply -f cm.yml
 - выполнить  команду kubectl apply -f storageClass.yml
 - выполнить  команду kubectl apply -f pvc.yml
 - выполнить  команду kubectl apply -f deployment.yml 
 - выполнить  команду kubectl apply -f service.yml  
 - выполнить  команду kubectl apply -f ingress.yml

## Как проверить работоспособность:
 - выполнить команду `kubectl get pods -n homework` и убедиться, что все поды в статусе Running и в колонке Ready стоит 1/1 для каждого пода.
 - выполнить команду `kubectl describe deployment webserver -n homework` и убедиться в наличии созданных volume PersistentVolumeClaim и volume ConfigMap.
 - выполнить команду `curl -XGET http://homework.otus/conf/file` и убедиться, что отображается созданного configMap.
 - выполнить команду `kubectl describe sc -n homework` и убедиться, что Provisioner установлен - k8s.io/minikube-hostpath, а ReclaimPolicy установлен - Retain
 -выполнить команду  `kubectl describe pvc pvc-webserver -n homework` и убедиться, что StorageClass выбран созданный sc-homework

## PR checklist:
 - [ x] Выставлен label с темой домашнего задания
